### PR TITLE
PR-69: Remove exp_introduction_ columns

### DIFF
--- a/R/get_daily_PEER_data.R
+++ b/R/get_daily_PEER_data.R
@@ -70,6 +70,7 @@ generate_map_assets <- function(ascertainment_bias = 4,
             ) %>% 
             dplyr::mutate(
                 # Expected number of event attendees arriving infected
+                # This is commented out, since the calc is happening on the PEER app frontend
                 # exp_introductions = (pInf*AB*size), # on the front end, will want to set 0 to <1,
                 # Cases per 100k in the past 14 days
                 cases_per_100k_past_14_d = round(pInf*(7/5)*1e5, 3) # need to multiple by 14/10 because to estimate case prevalence (pInf) 
@@ -84,7 +85,7 @@ generate_map_assets <- function(ascertainment_bias = 4,
     
     # Pivot data from long to wide so that there are columns for each event size
     GLOBALDATAWIDE <- GLOBALDATAALL %>% 
-        tidyr::pivot_wider(names_from = n, values_from = c(risk))
+      tidyr::pivot_wider(names_from = n, values_from = risk, names_prefix = 'risk_')
     
     # Unit test to make sure that all countries have estimates for risk regardless of event size
     stopifnot('Not all datasets are the same number of rows' = nrow(GLOBALDATAALL) == length_data*length(event_sizes))
@@ -92,7 +93,7 @@ generate_map_assets <- function(ascertainment_bias = 4,
     # Write output fgb file
     sf::st_write(
         sf::st_as_sf(GLOBALDATAWIDE),
-        glue::glue("{prefix}/globalDataDaily.{format}")
+        glue::glue("{prefix}/globalDataWide.{format}")
     )
 }
 data<-generate_map_assets()

--- a/R/get_daily_PEER_data.R
+++ b/R/get_daily_PEER_data.R
@@ -62,7 +62,7 @@ generate_map_assets <- function(ascertainment_bias = 4,
         
         THISGLOBALDATA <- GLOBALDATA %>%
             filter(!Country %in% excluded_countries) |>
-            dplyr::mutate(risk = round(calc_risk_raw(pInf * AB, size),3),
+            dplyr::mutate(risk = round(100 * calc_risk_raw(pInf * AB, size),3),
                           n = size) %>% 
             dplyr::mutate(
                 #risk = ifelse( risk ==1, '> 99', risk), # will handle in frontend
@@ -70,9 +70,9 @@ generate_map_assets <- function(ascertainment_bias = 4,
             ) %>% 
             dplyr::mutate(
                 # Expected number of event attendees arriving infected
-                exp_introductions = round(pInf*AB*size), # on the front end, will want to set 0 to <1,
+                # exp_introductions = (pInf*AB*size), # on the front end, will want to set 0 to <1,
                 # Cases per 100k in the past 14 days
-                cases_per_100k_past_14_d = pInf*(7/5)*1e5 # need to multiple by 14/10 because to estimate case prevalence (pInf) 
+                cases_per_100k_past_14_d = round(pInf*(7/5)*1e5, 3) # need to multiple by 14/10 because to estimate case prevalence (pInf) 
                 # we cases in the past 14 days by 10 and dive by 14 (so need to undo it)
             )
         
@@ -84,7 +84,7 @@ generate_map_assets <- function(ascertainment_bias = 4,
     
     # Pivot data from long to wide so that there are columns for each event size
     GLOBALDATAWIDE <- GLOBALDATAALL %>% 
-        tidyr::pivot_wider(names_from = n, values_from = c(risk, exp_introductions))
+        tidyr::pivot_wider(names_from = n, values_from = c(risk))
     
     # Unit test to make sure that all countries have estimates for risk regardless of event size
     stopifnot('Not all datasets are the same number of rows' = nrow(GLOBALDATAALL) == length_data*length(event_sizes))
@@ -92,7 +92,7 @@ generate_map_assets <- function(ascertainment_bias = 4,
     # Write output fgb file
     sf::st_write(
         sf::st_as_sf(GLOBALDATAWIDE),
-        glue::glue("{prefix}/dailyPeerData.{format}")
+        glue::glue("{prefix}/globalDataDaily.{format}")
     )
 }
 data<-generate_map_assets()


### PR DESCRIPTION
# Description

Removed the `exp_introductions` columns and trimmed data output down by 13 columns (~120K cells), for a reduced .fgt file and improved page load. Also, outputs risk as a percentage (*100), in order to avoid calculating that on the frontend for the choropleth visualization.

Fixes [PR-69](https://the-rockefeller-foundation.atlassian.net/browse/PR-69)
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# Testing/QA

- [ ] Test - In R studio, run the `get_daily_PEER_data.R` script to output an fgb file that does not contain the `exp_introduction` columns.
